### PR TITLE
upgrade psr/log to 1|2|3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         }
     },
     "require": {
-        "php": "^8.0 | ^8.1",
+        "php": "^8.0",
         "symfony/process": "~5.0 | ~6.0",
         "symfony/options-resolver": "~5.0 | ~6.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0 | ^2.0 | ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.5",


### PR DESCRIPTION
A lot of package now require psr/log 2 or 3 to work.

This PR allows upgrading to PSR 2 or 3.

The changelog can be found here: https://github.com/php-fig/log/releases

> ## 2.0
> Updated parameter types and added property types (https://github.com/php-fig/log/pull/76)
> Removed test files
> Require PHP 8.0 or above
> 
> ## 3.0
> Add return type (https://github.com/php-fig/log/pull/77)